### PR TITLE
enable FP_Qaunt on xpu, validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ import torch
 model_name = "ISTA-DASLab/Llama-3.1-8B-Instruct-MR-GPTQ-nvfp"
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 
+device = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
+
 model = AutoModelForCausalLM.from_pretrained(
     model_name,
-    device_map="cuda",
+    device_map=device,
     torch_dtype=torch.bfloat16,
 )
 prompt = "Explain quantization for neural network in simple terms."
-inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
+inputs = tokenizer(prompt, return_tensors="pt").to(device)
 with torch.inference_mode():
     output_tokens = model.generate(**inputs,max_new_tokens=150 )
 generated_text = tokenizer.decode(output_tokens[0], skip_special_tokens=True)

--- a/inference_lib/src/fp_quant/module/linear.py
+++ b/inference_lib/src/fp_quant/module/linear.py
@@ -151,9 +151,11 @@ class FPQuantLinear(nn.Module):
         assert self.weight.shape[1] % self.config.hadamard_group_size == 0, (
             f"Weight shape must be divisible by hadamard group size: {self.weight.shape[1]} % {self.config.hadamard_group_size} = {self.weight.shape[1] % self.config.hadamard_group_size}"
         )
+
+        weight_in_device = (self.weight.data.device.type in ["cuda", "xpu"])
         if not self.config.pseudoquantization:
-            assert self.weight.data.is_cuda, (
-                f"Weight must be on CUDA, but is on {self.weight.device}"
+            assert weight_in_device, (
+                f"Weight must be on CUDA or XPU, but is on {self.weight.device}"
             )
         if self.config.transform_init == "hadamard":
             transform_init_fn = get_hadamard_matrix

--- a/inference_lib/src/fp_quant/module/triton/mxfp4.py
+++ b/inference_lib/src/fp_quant/module/triton/mxfp4.py
@@ -142,7 +142,7 @@ def mxfp4_forward_kernel_wrapper(
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
 
     # Launch optimized kernel
-    with torch.cuda.device(x.device):
+    with torch.device(x.device):
         mxfp4_forward_kernel[grid](
             x_ptr=x,
             hadamard_matrix_ptr=hadamard_matrix,

--- a/inference_lib/src/fp_quant/module/triton/nvfp4.py
+++ b/inference_lib/src/fp_quant/module/triton/nvfp4.py
@@ -123,7 +123,7 @@ def nvfp4_forward_kernel_wrapper(
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
 
     # Launch optimized kernel
-    with torch.cuda.device(x.device):
+    with torch.device(x.device):
         nvfp4_forward_kernel[grid](
             x_ptr=x,
             hadamard_matrix_ptr=hadamard_matrix,

--- a/model_quant.py
+++ b/model_quant.py
@@ -24,8 +24,9 @@ try:
 except ImportError:
     wandb = None
 
-torch.backends.cuda.matmul.allow_tf32 = False
-torch.backends.cudnn.allow_tf32 = False
+if torch.cuda.is_available():
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
 
 
 def auto_or_int(value):
@@ -347,7 +348,7 @@ def main():
     # Fix seed
     fix_seed(args.seed)
     # Set device
-    device = "cuda"
+    device = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
     # Get dtype
     if args.dtype != "auto":
         args.dtype = getattr(torch, args.dtype)

--- a/src/transforms/matrix.py
+++ b/src/transforms/matrix.py
@@ -138,7 +138,7 @@ def sample_chi(d, rng=None, device='cpu'):
         d (int): The degrees of freedom for the Chi distribution. Also determines the shape of the matrix.
         rng (np.random.RandomState or np.random.Generator, optional): 
             A NumPy random number generator for seeding. If None, uses PyTorch's default RNG.
-        device (str or torch.device): The device on which to perform computation ('cpu' or 'cuda').
+        device (str or torch.device): The device on which to perform computation ('cpu', 'cuda' or 'xpu').
 
     Returns:
         torch.Tensor: A 1D tensor of length `d`, where each entry is a sample from Chi(d).
@@ -161,4 +161,4 @@ def sample_chi(d, rng=None, device='cpu'):
     # This gives `d` samples from a Chi distribution with `d` degrees of freedom
     chi_samples = torch.norm(normal_samples, dim=1)
 
-    return chi_samples 
+    return chi_samples

--- a/src/transforms/transforms.py
+++ b/src/transforms/transforms.py
@@ -232,10 +232,11 @@ class FastFoodTransform(BaseTransform):
         '''
         
         super().__init__()
+        device = torch.accelerator.current_accelerator().type if hasattr(torch, "accelerator") else "cuda"
         sigma = 1 / math.sqrt(2)
         B = torch.diag(torch.randint(0, 2, (group_size,)).float() * 2 - 1)
         G = torch.diag(torch.randn(group_size))
-        H = hadamard_transform(torch.eye(group_size, device='cuda')).cpu()
+        H = hadamard_transform(torch.eye(group_size, device=device)).cpu()
         S = torch.diag((1 / l2norm_along_axis1(G)) *  sample_chi(group_size))
         P = torch.eye(group_size)[torch.randperm(group_size, device='cpu')].to(torch.float32)
         self.block_mat = (1 / sigma) *(1 / math.sqrt(group_size) )*(S@H@G@P@H@B)

--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -14,6 +14,15 @@ def fix_seed(seed: int):
     torch.backends.cudnn.deterministic = True
 
 
+def clear_device_cache(garbage_collection=False):
+    if garbage_collection:
+        gc.collect()
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif torch.xpu.is_available():
+        torch.xpu.empty_cache()
+
 def to(data: Any, *args, **kwargs):
     """
     # adopted from https://github.com/Yura52/delu/blob/main/delu/_tensor_ops.py


### PR DESCRIPTION
Since 2.6, PyTorch introduce [`torch.accelerator`](https://docs.pytorch.org/docs/stable/accelerator.html) to extend built-in device support beyond CUDA GPU. Other accelerators like Intel XPU already supported through this mechanism officially by PyTorch.

In this PR, we want to extend FP_Quant support to Intel XPU, too. Hugging Face transformers FP-Quant psedo-quant(w/ triton backend) test cases are all passed on XPU. For QUBLAS backend, since current gen of Intel XPU doesn't support MIXFP4/NVFP4 in hardware yet, we will start to support once our next Gen XPU [Crescent Island](https://newsroom.intel.com/artificial-intelligence/intel-to-expand-ai-accelerator-portfolio-with-new-gpu) is out. But it will not impact this PR.

The code is back-compatible, when users install a earlier torch which doesn't support, it will fallback to directly use cuda.

Thx very much.
