### PR TITLE
Fix missing import

### DIFF
--- a/src/utils/common_utils.py
+++ b/src/utils/common_utils.py
@@ -1,3 +1,4 @@
+import gc
 import random
 import inspect
 import dataclasses


### PR DESCRIPTION
Running the sample command in the readme currently fails due to a missing import error when `gc.collect()` is run. This change fixes that issue.